### PR TITLE
Change date types to just string, with no `date-time` modifier 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 artifactMajorVersion = 0
 artifactMinorVersion = 1
-artifactPatchVersion = 2
+artifactPatchVersion = 3
 
 applicationGroupId = com.elyxor.cachethq
 applicationTitle = Cachet HQ okhttp-gson API Client (java)

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -739,13 +739,10 @@ definitions:
         format: int32
       created_at:
         type: string
-        format: date-time
       updated_at:
         type: string
-        format: date-time
       deleted_at:
         type: string
-        format: date-time
       status_name:
         type: string
       tags:
@@ -798,10 +795,8 @@ definitions:
         type: string
       created_at:
         type: string
-        format: date-time
       updated_at:
         type: string
-        format: date-time
       order:
         type: integer
         format: int32
@@ -869,16 +864,12 @@ definitions:
         type: string
       scheduled_at:
         type: string
-        format: date-time
       created_at:
         type: string
-        format: date-time
       updated_at:
         type: string
-        format: date-time
       deleted_at:
         type: string
-        format: date-time
       human_status:
         type: string
 
@@ -906,7 +897,6 @@ definitions:
         format: boolean
       created_at:
         type: string
-        format: date-time
       template:
         type: string
       vars:
@@ -931,10 +921,8 @@ definitions:
         format: int32
       created_at:
         type: string
-        format: date-time
       updated_at:
         type: string
-        format: date-time
       human_status:
         type: string
       permalink:
@@ -995,10 +983,8 @@ definitions:
         type: boolean
       created_at:
         type: string
-        format: date-time
       updated_at:
         type: string
-        format: date-time
       places:
         type: integer
         format: int32
@@ -1067,10 +1053,8 @@ definitions:
         type: number
       created_at:
         type: string
-        format: date-time
       updated_at:
         type: string
-        format: date-time
 
   MetricPoint:
     type: object
@@ -1079,7 +1063,6 @@ definitions:
         type: number
       timestamp:
         type: string
-        format: date-time
 
   Ping:
     type: object


### PR DESCRIPTION
This was causing an issue because the Cachet API returns datetimes in
 the format `2018-10-15 13:58:41` which cannot be parsed by the
 `ISODateTimeFormat.dateOptionalTimeParser();` in the `DateTimeTypeAdapter` class